### PR TITLE
remove error control operator

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -28,7 +28,7 @@ function polr_plugin_options() { // Page design. This function is called in admi
         <h2>Polr Wordpress Plugin</h2>
         <form action="<?php echo esc_url( admin_url('options.php') ); ?>" method="post">
             <?php settings_fields('polr-group'); ?>
-            <?php @do_settings_fields('polr-group'); ?>
+            <?php do_settings_fields('polr-group'); ?>
             <table class="form-table">
 							<tr valign="top">
 									<th scope="row"><label for="polr_settings_host_title"><?php echo esc_html(__('Host URL', 'wp-polr')); ?></label></th>
@@ -43,7 +43,7 @@ function polr_plugin_options() { // Page design. This function is called in admi
                         <br/><small><?php echo esc_html(__('You find the API key in your dashboard', 'wp-polr')); ?></small>
                     </td>
                 </tr>
-            </table> <?php @submit_button(); ?>
+            </table> <?php submit_button(); ?>
         </form>
     </div>
     <?php


### PR DESCRIPTION
The error control operator also suppresses critical errors, so you should never use it. This text taken from the PHP docs:
"Currently the "@" error-control operator prefix will even disable error reporting for critical errors that will terminate script execution. Among other things, this means that if you use "@" to suppress errors from a certain function and either it isn't available or has been mistyped, the script will die right there with no indication as to why."
http://php.net/manual/en/language.operators.errorcontrol.php